### PR TITLE
Fixes issue #21 by checking the ref received by the GitHub API on push event

### DIFF
--- a/src/main/java/group8/Utilities.java
+++ b/src/main/java/group8/Utilities.java
@@ -7,6 +7,8 @@ import com.google.gson.JsonSyntaxException;
 import javax.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
 
 public class Utilities {
 
@@ -41,4 +43,29 @@ public class Utilities {
             return "";
         }
     }
+
+
+    /**
+     * Takes a ref name refs/heads/issue/1 and returns issue1 to be used to sort filesystem.
+     * @param fullRef - Received from GitHub API as refs/heads/issue/1
+     * @return the ref suffix without slashes, i.e. refs/heads/issue/1 -> issue1
+     */
+    public static String getRefSuffix(String fullRef) {
+        String[] splitRef = fullRef.split("/");
+        // if the input string does not contain /, just return the input.
+        if (splitRef.length > 1) {
+            String[] subArray = Arrays.copyOfRange(splitRef, 2, splitRef.length);
+            String branch = "";
+            for (String i: subArray) {
+                branch += i;
+            }
+            return branch;
+        }
+        return fullRef;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(getRefSuffix("refs/heads/issue/1"));
+    }
+
 }

--- a/src/main/java/group8/git/GitRepoFetcher.java
+++ b/src/main/java/group8/git/GitRepoFetcher.java
@@ -2,21 +2,43 @@ package group8.git;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.TextProgressMonitor;
 
 import java.io.File;
+import java.io.PrintWriter;
+import java.nio.file.FileSystemNotFoundException;
+import java.util.Arrays;
 
+/**
+ * Fetches a GitHub repository using JGit.
+ */
 public class GitRepoFetcher {
     String repoUrl;
+    String ref;
 
-    public GitRepoFetcher(String repoUrl) {
+    /**
+     * Constructor for the GitRepoFetcher class.
+     * @param repoUrl - the url of the repository
+     * @param ref - the full branch name on which the new push has occurred and which we have to clone.
+     */
+    public GitRepoFetcher(String repoUrl, String ref) {
         this.repoUrl = repoUrl;
+        this.ref = ref;
+        System.out.println(Arrays.asList(this.ref));
     }
 
+    /**
+     * Triggers the instance to fetch the desired repo to a certain location
+     * @param destination - the location in which the fetched repo will be stored.
+     */
     public void fetchToDestination(File destination) {
         try {
             Git.cloneRepository()
-                    .setURI("https://github.com/DD2480-Group-8/DD2480-CI.git")
+                    .setProgressMonitor(new TextProgressMonitor(new PrintWriter(System.out))) // allows us to see progress of the fetching.
                     .setDirectory(destination)
+                    .setURI("https://github.com/DD2480-Group-8/DD2480-CI.git")
+                    .setBranchesToClone(Arrays.asList(this.ref))
+                    .setBranch(this.ref) // checkout the newly fetched branch.
                     .call();
         } catch (GitAPIException e) {
             e.printStackTrace();

--- a/src/main/java/group8/server/ContinuousIntegrationServer.java
+++ b/src/main/java/group8/server/ContinuousIntegrationServer.java
@@ -47,7 +47,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         String repoName = requestJson.get("repository").getAsJsonObject().get("name").getAsString();
         String ownerName = requestJson.get("repository").getAsJsonObject().get("owner").getAsJsonObject().get("name").getAsString();
         String ref = requestJson.get("ref").getAsString();
-        System.out.println(ref);
+        String branchName = Utilities.getRefSuffix(ref);
         GitCommitStatus commitStatus = new GitCommitStatus(ownerName, repoName, commitSha);
 
         //Sends the PENDING status to GitHub.
@@ -61,7 +61,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         // 2nd compile the code
         System.out.println("Cloning repo...");
         String currentDate = CurrentDate.getCurrentDate();
-        String destinationPath = String.format("./builds/DD2480-CI-%s", currentDate);
+        String destinationPath = String.format("./builds/%s/DD2480-CI-%s", branchName, currentDate);
         File destinationDirectory = new File(destinationPath);
         GitRepoFetcher repo = new GitRepoFetcher("https://github.com/DD2480-Group-8/DD2480-CI.git", ref);
         repo.fetchToDestination(destinationDirectory);

--- a/src/main/java/group8/server/ContinuousIntegrationServer.java
+++ b/src/main/java/group8/server/ContinuousIntegrationServer.java
@@ -46,6 +46,8 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         String commitSha = requestJson.get("after").getAsString();
         String repoName = requestJson.get("repository").getAsJsonObject().get("name").getAsString();
         String ownerName = requestJson.get("repository").getAsJsonObject().get("owner").getAsJsonObject().get("name").getAsString();
+        String ref = requestJson.get("ref").getAsString();
+        System.out.println(ref);
         GitCommitStatus commitStatus = new GitCommitStatus(ownerName, repoName, commitSha);
 
         //Sends the PENDING status to GitHub.
@@ -61,7 +63,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         String currentDate = CurrentDate.getCurrentDate();
         String destinationPath = String.format("./builds/DD2480-CI-%s", currentDate);
         File destinationDirectory = new File(destinationPath);
-        GitRepoFetcher repo = new GitRepoFetcher("https://github.com/DD2480-Group-8/DD2480-CI.git");
+        GitRepoFetcher repo = new GitRepoFetcher("https://github.com/DD2480-Group-8/DD2480-CI.git", ref);
         repo.fetchToDestination(destinationDirectory);
         System.out.println("Repo cloned.");
 

--- a/src/test/java/group8/UtilitiesTest.java
+++ b/src/test/java/group8/UtilitiesTest.java
@@ -65,4 +65,14 @@ public class UtilitiesTest {
         );
     }
 
+    @Test
+    public void getRefSuffixValidTest() {
+        Assert.assertEquals("issue1", Utilities.getRefSuffix("refs/heads/issue/1"));
+    }
+
+    @Test
+    public void getRefSuffixInvalidTest() {
+        Assert.assertEquals("containsNoSlashes", Utilities.getRefSuffix("containsNoSlashes"));
+    }
+
 }


### PR DESCRIPTION
Also implements helperfunction + test, as well as new folder hierarchy to keep track of builds on specific branch.
 new structure is /builds/<branch>/<repo+dateTime>
This change does not affect log parsing functionality.